### PR TITLE
fix: only include lib folder to final npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
     "peerDependencies": {
         "aws-sdk": "^2.1106.0"
     },
+    "peerDependenciesMeta": {
+        "aws-sdk": {
+            "optional": true
+        }
+    },
     "dependencies": {
         "uuid": "^8.3.2"
     }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "license": "MIT",
     "description": "Distributed locking library backed by DynamoDB.",
     "main": "./lib/index.js",
+    "files": [
+        "lib/"
+    ],
     "scripts": {
         "self-peers": "install-self-peers -- --ignore-scripts",
         "prepare": "yarn self-peers && yarn format && yarn lint && yarn compile",


### PR DESCRIPTION
This will prevent unnecessary files to be included in the final NPM package. Also, the `aws-sdk` will be set as an optional peer dependency.